### PR TITLE
:bug: Destroy the renderer before the window

### DIFF
--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -376,8 +376,8 @@ bool Grapic::display()
 void Grapic::quit()
 {
     TTF_CloseFont(m_font);
-    SDL_DestroyWindow(m_window);
     SDL_DestroyRenderer(m_renderer);
+    SDL_DestroyWindow(m_window);
     m_font = NULL;
     m_window = NULL;
     m_renderer = NULL;


### PR DESCRIPTION
Vu que le renderer doit être attaché à une fenêtre, détruire la fenêtre avant le renderer rend l'opération SDL_DestroyRenderer() imprévisible, et aboutit souvent à une erreur à la destruction de la fenêtre. Juste inverser l'ordre de destruction des objets fixe ce problème