### PR TITLE
Rework of plot system to include titles, axis and legends and customization

### DIFF
--- a/apps/tutorials/tuto8_Plot.cpp
+++ b/apps/tutorials/tuto8_Plot.cpp
@@ -1,49 +1,68 @@
 #include <Grapic.h>
-#include <iostream>
-#include <cmath>
-
-using namespace std;
 using namespace grapic;
 
 const int WIN_DIM_X = 600;
 const int WIN_DIM_Y = 500;
 
-
-
-
 int main(int , char** )
 {
-    bool stop=false;
     winInit("Demo", WIN_DIM_X, WIN_DIM_Y);
-    setKeyRepeatMode(true);
 
     Plot p1, p2;
-    plot_setSize(p2, 1000);						// For the graph/plot p2 the number of value will be 1000 maximum
-    float x,y,y2;
+
+    // Plot titles
+    plot_title(p1, "First graph");
+    plot_title(p2, "Second graph");
+    // Define where plot are drawn
+    plot_area(p1, 20,               20, WIN_DIM_X - 20, WIN_DIM_Y/2 - 20 );
+    plot_area(p2, 20, WIN_DIM_Y/2 + 20, WIN_DIM_X - 20, WIN_DIM_Y   - 20);
+
+    // Axis options     
+    plot_yaxisTitle(p1, "Time"); // Set yaxis title to "Time"
+    plot_xaxisType (p2, "log");  // Set xaxis of p2 to be in log-scaled
+
+    // Curve options
+    // Curve names
+    plot_curveName(p1, 0, "cos"); // curve 0 of p1 will be labeled "cos"
+    plot_curveName(p1, 1, "sin"); // curve 1 of p1 will be labeled "sin"
+    plot_curveName(p2, 0, "cos2"); 
+    plot_curveName(p2, 1, "sin*0.5");
+    
+    // Curve types
+    plot_curveType(p2, 1, "scatter"); // Only points
+    
+    // Location
+    plot_legendLocation(p1, "botright");     // Bot right
+    plot_legendLocation(p2, "centercenter"); // Center of the plot
+
+    // Legend title
+    plot_legendTitle(p1, "Curves");
+    plot_legendTitle(p2, "Points");
+
+    float x, y, y2;
     x = 0.f;
-    while( !stop )                              // The application is running in a loop and call the draw function all the time.
+
+    bool stop = false;
+
+    while( !stop )
     {
-        //x = elapsedTime();
-        x += 0.01f;
-        y = cos(x);
-        y2 = 0.5*sin(x);
-
-        plot_add(p1, x, y);						// add a dot in the graph p1, curve number 0(=the default)
-        plot_add(p1, x, y2,1);					// add a dot in the graph p1, curve number 1
-
-        plot_add(p2, x, y);						// add a dot in the graph p2, curve0;  if 1000 values are already stored in p2, the lowest is removed
-        plot_add(p2, x, y2,1);					// add a dot in the graph p2, curve1;  if 1000 values are already stored in p2, the lowest is removed
-
-
-        backgroundColor( 55, 0, 0);
         winClear();
 
-        color( 255, 0,0);
-        plot_draw( p1, 20, 20, WIN_DIM_X-20, WIN_DIM_Y/2-20 );						// draw the graph p1
-        plot_draw( p2, 20, WIN_DIM_Y/2+20, WIN_DIM_X-20, WIN_DIM_Y-20, false );			// draw the graph p2 on the top of the window
+        x += 0.1f;
+        y = cos(x);
+        y2 = 0.5 * sin(x);
 
-        stop = winDisplay();
+        // Add data to plot
+        plot_add(p1, x,  y, 0);
+        plot_add(p1, x, y2, 1);
+        plot_add(p2, x,  y, 0);
+        plot_add(p2, x, y2, 1);
+
+        // Draw plots
+        plot_draw(p1);
+        plot_draw(p2);
+
+        stop = winDisplay();    
     }
-    winQuit();
-    return 0;
+	return 0;
 }

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -173,22 +173,6 @@ void Menu::change(int i, const std::string& str)
         std::cerr<<"menu_change(...): i is not in the range of the menu"<<std::endl;
 }
 
-    Plot::Plot() : m_nb_plot_max(-1) {}
-
-    void Plot::clear()
-    {
-        for(int i=0; i<m_dat.size(); ++i)
-            m_dat[i].clear();
-        m_dat.clear();
-    }
-
-    void Plot::setSize(const int n)
-    {
-        clear();
-        m_nb_plot_max = n;
-    }
-
-
 int Menu::select() const
 {
     return m_select;
@@ -587,7 +571,8 @@ int filledEllipseRGBA(SDL_Renderer* m_renderer, Sint16 x, Sint16 y, Sint16 rx, S
     * Set color
     */
     result = 0;
-    result |= SDL_SetRenderDrawBlendMode(m_renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+    // TODO : CHeck this line. It is commented because it destroys any other drawing using alpha mode (see lines 590, 708, 791)
+    // result |= SDL_SetRenderDrawBlendMode(m_renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
     result |= SDL_SetRenderDrawColor(m_renderer, r, g, b, a);
 
     /*
@@ -703,7 +688,9 @@ int filledEllipseRGBA(SDL_Renderer* m_renderer, Sint16 x, Sint16 y, Sint16 rx, S
 int pixelRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
     int result = 0;
-    result |= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+    
+    // TODO : CHeck this line. It is commented because it destroys any other drawing using alpha mode (see lines 590, 708, 791)
+    // result |= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
     result |= SDL_SetRenderDrawColor(renderer, r, g, b, a);
     result |= SDL_RenderDrawPoint(renderer, x, y);
     return result;
@@ -784,7 +771,9 @@ int aaellipseRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rx, Sint16
 
     /* Draw */
     result = 0;
-    result |= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
+    
+    // TODO : CHeck this line. It is commented because it destroys any other drawing using alpha mode (see lines 590, 708, 791)
+    // result |= SDL_SetRenderDrawBlendMode(renderer, (a == 255) ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
 
     /* "End points" */
     result |= pixelRGBA(renderer, xp, yp, r, g, b, a);
@@ -983,6 +972,21 @@ void print(int x, int y, const char* txt)
     SDL_FreeSurface(textSurface);
     SDL_Rect renderQuad = { x, g.inverseY(y+text_height), text_width, text_height };
     SDL_RenderCopy( g.renderer(), text, nullptr, &renderQuad);
+    SDL_DestroyTexture(text);
+}
+
+/* Expose this function ? */
+void print_rotated(int x, int y, double angle, const char* txt)
+{
+    Grapic& g = Grapic::singleton();
+    SDL_Surface* textSurface = TTF_RenderText_Solid( g.font(), txt, g.getColor() );
+    SDL_Texture* text = SDL_CreateTextureFromSurface( g.renderer(), textSurface);
+    int text_width = textSurface->w;
+    int text_height = textSurface->h;
+    SDL_FreeSurface(textSurface);
+
+    SDL_Rect renderQuad = { x, g.inverseY(y+text_height), text_width, text_height };
+    SDL_RenderCopyEx( g.renderer(), text, nullptr, &renderQuad, angle, NULL, SDL_FLIP_NONE);
     SDL_DestroyTexture(text);
 }
 
@@ -1477,126 +1481,941 @@ struct sort_pred
     }
 };
 
-void Plot::add(float x, float y, int curve_n)
+
+NumberFormatter::~NumberFormatter() {} 
+
+FixedPrecisionFormatter::FixedPrecisionFormatter(unsigned int precision) :
+    precision(precision)
+{ }
+
+std::string FixedPrecisionFormatter::format(float number) const
 {
-    if (curve_n<0)
+    std::ostringstream out;
+    out.precision(precision);
+    out << std::fixed << number;
+    return out.str();
+}
+
+ScientificFormatter::ScientificFormatter(unsigned int precision) :
+    precision(precision)
+{ }
+
+std::string ScientificFormatter::format(float number) const
+{
+    std::ostringstream out;
+    out.precision(precision);
+    out << std::scientific << number;
+    return out.str();
+}
+
+Theme Theme::defaultTheme;
+
+Theme::Theme()
+{
+    // Default theme settings
+    axisTheme.axisColor = {0, 0, 0, 255};
+    axisTheme.gridColor = {100, 100, 100, 100};
+
+    axisTheme.showGrid = true;
+    axisTheme.showTicks = true;
+    axisTheme.showTitle = true;
+    axisTheme.defaultTicksCount = 5;
+    
+    axisTheme.ticksSize = 3;
+    axisTheme.ticksSpacing = 5; 
+
+    axisTheme.ticksFontSize = 13;
+    axisTheme.titleFontSize = 11;
+
+    axisTheme.formatter = std::make_shared<FixedPrecisionFormatter>();
+
+    plotTheme.titleColor = { 0, 0, 0, 255};
+    plotTheme.backgroundColor = { 255, 255, 255, 255 };
+    plotTheme.borderColor = { 0, 0, 0, 255 };
+    plotTheme.titleFontSize = 15;
+
+    legendTheme.legendEntrySpacing = 10;
+    legendTheme.legendPadding      =  5;
+    legendTheme.legendDescSize     = 20;
+    legendTheme.legendDescSpacing  = 10;
+
+    legendTheme.legendTitleFontsize = 13;
+    legendTheme.legendEntryFontsize = 11;
+
+    legendTheme.legendEntryColor = {0, 0, 0, 255};
+    legendTheme.legendTitleColor = {0, 0, 0, 255};
+    legendTheme.backgroundColor  = {255, 255, 255, 255};
+
+    defaultColorPalette[0] = { 0x1f, 0x77, 0xb4, 0xff };
+    defaultColorPalette[1] = { 0xff, 0x7f, 0x0e, 0xff };
+    defaultColorPalette[2] = { 0x2c, 0xa0, 0x2c, 0xff };
+    defaultColorPalette[3] = { 0xd6, 0x27, 0x28, 0xff };
+    defaultColorPalette[4] = { 0x94, 0x67, 0xbd, 0xff };
+    defaultColorPalette[5] = { 0x8c, 0x56, 0x4b, 0xff };
+    defaultColorPalette[6] = { 0xe3, 0x77, 0xc2, 0xff };
+    defaultColorPalette[7] = { 0x7f, 0x7f, 0x7f, 0xff };
+    defaultColorPalette[8] = { 0xbc, 0xbd, 0x22, 0xff };
+    defaultColorPalette[9] = { 0x17, 0xbe, 0xcf, 0xff };
+}
+
+Point::Point() : x(0), y(0)
+{ }
+
+Point::Point(int x, int y) : x(x), y(y)
+{ }
+
+Size::Size() : width(0), height(0)
+{ }
+
+Size::Size(int x, int y) : width(x), height(y)
+{ }
+
+Rect::Rect() : pos(), size()
+{ }
+
+Rect::Rect(const Point& p, const Size& s) : pos(p), size(s)
+{ }
+
+Rect::Rect(int x, int y, int w, int h) : pos(x, y), size(w, h) 
+{ }
+
+Axis::Axis() :
+    m_theme(nullptr),
+    m_title(""),
+    m_max(-std::numeric_limits<float>::infinity()),
+    m_min( std::numeric_limits<float>::infinity()),
+    m_ticks{},
+    m_boundsSet(false),
+    m_ticksSet(false),
+    m_plotarea(0, 0, 0, 0)
+{ }
+
+void Axis::copyParams(Axis* to) const
+{
+    if (to)
     {
-        cerr<<"error==> plot_add: curve number invalid"<<endl;
-        return;
+        to->m_theme = m_theme;
+        to->m_title = m_title;
+        to->m_max = m_max;
+        to->m_min = m_min;
+        to->m_ticks = m_ticks;
+        to->m_boundsSet = m_boundsSet;
+        to->m_ticksSet = m_ticksSet;
+        to->m_plotarea = m_plotarea;
     }
-    if (curve_n>=m_dat.size()) m_dat.resize(curve_n+1);
-    Curve& curve = m_dat[curve_n];
-    if ((m_nb_plot_max<0) || (curve.size()<m_nb_plot_max))
+}
+
+void Axis::setTheme(AxisTheme* theme) 
+{
+    this->m_theme = theme;
+}
+
+void Axis::setTitle(const std::string& title)
+{
+    this->m_title = title;
+}
+
+void Axis::setPlotarea(const Rect& area)
+{
+    m_plotarea = area;
+}
+
+bool Axis::inBounds(float value) const
+{
+    return value >= m_min && value <= m_max;
+}
+
+void Axis::setBounds(float min, float max)
+{
+    this->m_min = min;
+    this->m_max = max;
+    this->m_boundsSet = true;
+    updateTicks(m_theme->defaultTicksCount);
+}
+
+bool Axis::updateBounds(float value)
+{
+    if (!m_boundsSet)
     {
-        curve.push_back( std::make_pair(x,y) );
-        std::sort(curve.begin(), curve.end(), sort_pred() );
+        std::size_t minLength = m_theme->formatter->format(m_min).size();
+        std::size_t maxLength = m_theme->formatter->format(m_max).size();
+
+        m_min = std::min(m_min, value);
+        m_max = std::max(m_max, value);
+        updateTicks(m_theme->defaultTicksCount);
+
+        std::size_t newMinLength = m_theme->formatter->format(m_min).size();
+        std::size_t newMaxLength = m_theme->formatter->format(m_max).size();
+
+        return (minLength != newMinLength) || (maxLength != newMaxLength);
+    }
+
+    return false;
+}
+
+void Axis::setTicks(const std::vector<float>& ticks)
+{
+    this->m_ticks = ticks;
+    this->m_ticksSet = true;
+}
+
+void Axis::updateTicks(std::size_t tickCount)
+{
+    if (!m_ticksSet)
+    {
+        m_ticks.resize(tickCount);
+        const float tickSpacing = (m_max - m_min) / (tickCount - 1);
+
+        for (std::size_t i = 0; i < tickCount; i++)
+            m_ticks[i] = m_min + i * tickSpacing;
+    }
+}
+
+Axis::~Axis() { }
+
+// Axis definition
+Size VerticalAxis::measure() const 
+{
+    if (m_theme)
+    {
+            Grapic& g = Grapic::singleton();
+
+        const int tickSize = m_theme->ticksSize;
+        const int spacing  = m_theme->ticksSpacing;
+
+        const float startX = m_plotarea.pos.x;
+        const float startY = m_plotarea.pos.y;
+        const float endX   = m_plotarea.pos.x + m_plotarea.size.width;
+        const float endY   = m_plotarea.pos.y + m_plotarea.size.height;
+
+        // Main line
+        int tmpW, tmpH;
+        int maxH = -std::numeric_limits<int>::infinity();
+        int maxW  = -std::numeric_limits<int>::infinity();
+        // Draw ticks
+        
+        fontSize(m_theme->ticksFontSize);
+        for (int i = 0; i < m_ticks.size(); i++)
+        {   
+            std::string strValue = m_theme->formatter->format(m_ticks.at(i));
+            TTF_SizeText(g.font(), strValue.c_str(), &tmpW, &tmpH);
+
+            maxW = std::max(maxW, tmpW);
+            maxH = std::max(maxH, tmpH);
+        }
+
+        fontSize(m_theme->titleFontSize);
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+
+        return Size(tickSize + 2 * spacing + maxW + tmpH, maxH / 2);
+    }
+
+    return Size();
+}
+
+float VerticalAxis::map(float value) const
+{
+    return m_plotarea.pos.y + (value - m_min) * m_plotarea.size.height / (m_max - m_min);
+}
+
+void VerticalAxis::draw() const
+{
+    if (m_theme)
+    {
+        Grapic& g = Grapic::singleton();
+
+        // TODO : Extract those, they are also used in measure function
+        const int tickSize = m_theme->ticksSize;
+        const int spacing  = m_theme->ticksSpacing;
+
+        const float startX = m_plotarea.pos.x;
+        const float startY = m_plotarea.pos.y;
+        const float endX   = m_plotarea.pos.x + m_plotarea.size.width;
+        const float endY   = m_plotarea.pos.y + m_plotarea.size.height;
+
+        // Main line
+        color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+        line(startX, startY, startX, endY);
+
+        int tmpW, tmpH;
+        int maxW = -std::numeric_limits<int>::infinity();
+
+        // Draw ticks
+        fontSize(m_theme->ticksFontSize);
+        for (int i = 0; i < m_ticks.size(); i++)
+        {   
+            std::string strValue = m_theme->formatter->format(m_ticks.at(i));
+            TTF_SizeText(g.font(), strValue.c_str(), &tmpW, &tmpH);
+
+            const float axisValue = map(m_ticks.at(i)); 
+
+            // Ticks
+            color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+            line(startX - tickSize, axisValue, startX + tickSize, axisValue);
+            print(
+                startX - tmpW - tickSize - spacing, 
+                axisValue - tmpH / 2,
+                strValue.c_str()
+            );
+
+            // Grid                
+            color(m_theme->gridColor.r, m_theme->gridColor.g, m_theme->gridColor.b, m_theme->gridColor.a);
+            line(startX, axisValue, endX, axisValue);
+            
+            maxW = std::max(maxW, tmpW);
+        }
+
+        color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+        fontSize(m_theme->titleFontSize);
+        
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+
+        print_rotated(
+            startX - maxW - tickSize - spacing - spacing - tmpH,
+            startY + m_plotarea.size.height / 2 - tmpW / 2,
+            -90,
+            m_title.c_str()
+        );
+    }
+}        
+
+Size HorizontalAxis::measure() const 
+{
+    if (m_theme)
+    {
+            Grapic& g = Grapic::singleton();
+
+        // TODO : Extract those, they are also used in measure function
+        const int tickSize = m_theme->ticksSize;
+        const int spacing  = m_theme->ticksSpacing;
+
+        const float startX = m_plotarea.pos.x;
+        const float startY = m_plotarea.pos.y;
+        const float endX   = m_plotarea.pos.x + m_plotarea.size.width;
+        const float endY   = m_plotarea.pos.y + m_plotarea.size.height;
+
+        int tmpW, tmpH;
+        int maxW = -std::numeric_limits<int>::infinity();
+        int maxH = -std::numeric_limits<int>::infinity();
+        
+        fontSize(m_theme->ticksFontSize);
+        for (int i = 0; i < m_ticks.size(); i++)
+        {   
+            std::string strValue = m_theme->formatter->format(m_ticks.at(i));
+            TTF_SizeText(g.font(), strValue.c_str(), &tmpW, &tmpH);
+            maxW = std::max(maxW, tmpW);
+            maxH = std::max(maxH, tmpH);
+        }
+
+        fontSize(m_theme->titleFontSize);
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+
+        return Size(maxW / 2, tickSize + 2 * spacing + maxH + tmpH);
+    }
+
+    return Size();
+}
+
+float HorizontalAxis::map(float value) const
+{        
+    return m_plotarea.pos.x + (value - m_min) * m_plotarea.size.width / (m_max - m_min);
+}
+
+void HorizontalAxis::draw() const
+{
+    if (m_theme)
+    {
+        Grapic& g = Grapic::singleton();
+
+        // TODO : Extract those, they are also used in measure function
+        const int tickSize = m_theme->ticksSize;
+        const int spacing  = m_theme->ticksSpacing;
+
+        const float startX = m_plotarea.pos.x;
+        const float startY = m_plotarea.pos.y;
+        const float endX   = m_plotarea.pos.x + m_plotarea.size.width;
+        const float endY   = m_plotarea.pos.y + m_plotarea.size.height;
+        
+        // Main line
+        color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+        line(startX, startY, endX, startY);
+
+        int tmpW, tmpH;
+        int maxH = -std::numeric_limits<int>::infinity();
+        // Draw ticks
+        fontSize(m_theme->ticksFontSize);
+        for (int i = 0; i < m_ticks.size(); i++)
+        {   
+            std::string strValue = m_theme->formatter->format(m_ticks.at(i));
+            TTF_SizeText(g.font(), strValue.c_str(), &tmpW, &tmpH);
+
+            const float axisValue = map(m_ticks.at(i));
+
+            // Ticks
+            color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+            line(axisValue, startY - tickSize, axisValue, startY + tickSize);
+            print(
+                axisValue - tmpW / 2,
+                startY - tmpH - tickSize - spacing,
+                strValue.c_str()
+            );
+
+            // Grid                
+            color(m_theme->gridColor.r, m_theme->gridColor.g, m_theme->gridColor.b, m_theme->gridColor.a);
+            line(axisValue, startY, axisValue, endY);
+
+            maxH = std::max(maxH, tmpH);
+        }
+
+        color(m_theme->axisColor.r, m_theme->axisColor.g, m_theme->axisColor.b, m_theme->axisColor.a);
+        fontSize(m_theme->titleFontSize);
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+        print(
+            startX + m_plotarea.size.width / 2 - tmpW / 2,
+            startY - maxH - tickSize - spacing - spacing - tmpH,
+            m_title.c_str()
+        );
+    }
+}        
+
+float VerticalLogAxis::map(float value) const
+{
+    const float base = 10.f;
+    auto sign = [](float val) -> int { return (0.f < val) - (val < 0.f); };
+    auto log = [&](float val) -> float {
+        return sign(val) * std::log(1 + std::abs(val)) / std::log(base);
+    };
+    auto exp = [&](float val) -> float {
+        return sign(val) * (std::exp(std::abs(val) * std::log(base)) - 1.f);
+    }; 
+
+    const float max = log(m_max);
+    const float min = log(m_min);
+    const float val = log(value);
+    const float percentage = (value - m_min) / (m_max - m_min);
+    
+    const float mapped_value = exp(min + percentage * (max - min));
+    
+    return m_plotarea.pos.y + (mapped_value - m_min) * m_plotarea.size.height / (m_max - m_min);
+}
+
+float HorizontalLogAxis::map(float value) const
+{
+    const float base = 10.f;
+    auto sign = [](float val) -> int { return (0.f < val) - (val < 0.f); };
+    auto log = [&](float val) -> float {
+        return sign(val) * std::log(1 + std::abs(val)) / std::log(base);
+    };
+    auto exp = [&](float val) -> float {
+        return sign(val) * (std::exp(std::abs(val) * std::log(base)) - 1.f);
+    }; 
+
+    const float max = log(m_max);
+    const float min = log(m_min);
+    const float val = log(value);
+    const float percentage = (value - m_min) / (m_max - m_min);
+    
+    const float mapped_value = exp(min + percentage * (max - min));
+    
+    return m_plotarea.pos.x + (mapped_value - m_min) * m_plotarea.size.width / (m_max - m_min);
+}
+
+DrawData::DrawData() : 
+    type(DrawData::DrawType::NONE),
+    color{ 0, 0, 0, 0},
+    name("")
+{ }
+
+Legend::Legend() : 
+    m_theme(nullptr),
+    m_position(0, 0),
+    m_title("T"),
+    m_data(nullptr)
+{
+}
+
+void Legend::setTitle(const std::string& title)
+{
+    this->m_title = title;
+}
+
+void Legend::setTheme(LegendTheme* theme)
+{
+    this->m_theme = theme;
+}
+
+void Legend::setData(std::vector<DrawData>* data)
+{
+    this->m_data = data;
+}
+
+void Legend::setPosition(const Point& p)
+{
+    this->m_position = p;
+}
+
+Size Legend::measure() const
+{
+    if (m_theme && m_data)
+    {
+        Grapic& g = Grapic::singleton();
+
+        int tmpW, tmpH;
+        int width = 0;
+        int height = m_theme->legendPadding;
+        
+        fontSize(m_theme->legendTitleFontsize);
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+
+        height += m_theme->legendPadding + tmpH;
+        width = tmpW;
+        height += m_theme->legendEntrySpacing;
+
+        fontSize(m_theme->legendEntryFontsize);
+        for (std::size_t i = 0; i < m_data->size(); ++i)
+        {
+            height += m_theme->legendEntrySpacing;
+            TTF_SizeText(g.font(), m_data->at(i).name.c_str(), &tmpW, &tmpH);
+            width = std::max(tmpW + m_theme->legendDescSize + m_theme->legendDescSpacing, width);
+            height += tmpH;
+        }
+        height += m_theme->legendPadding;
+        return Size(width + 2 * m_theme->legendPadding, height);
+    }
+
+    return Size(0, 0);
+}
+
+void Legend::draw() const
+{
+    if (m_theme && m_data)
+    {
+        Grapic& g = Grapic::singleton();
+        Size size = measure();
+
+        color(
+            m_theme->backgroundColor.r, 
+            m_theme->backgroundColor.g, 
+            m_theme->backgroundColor.b, 
+            m_theme->backgroundColor.a
+        );
+        rectangleFill(
+            m_position.x, 
+            m_position.y, 
+            m_position.x + size.width, 
+            m_position.y - size.height
+        );
+        color(0, 0, 0, 255);
+        rectangle(
+            m_position.x, 
+            m_position.y, 
+            m_position.x + size.width, 
+            m_position.y - size.height
+        );
+
+
+        int tmpW, tmpH;
+        int width = 0;
+        int height = m_position.y - m_theme->legendPadding;
+        
+        color(
+            m_theme->legendTitleColor.r, 
+            m_theme->legendTitleColor.g, 
+            m_theme->legendTitleColor.b, 
+            m_theme->legendTitleColor.a 
+        );
+        fontSize(m_theme->legendTitleFontsize);
+        TTF_SizeText(g.font(), m_title.c_str(), &tmpW, &tmpH);
+        print(m_position.x + size.width / 2 - tmpW / 2, height - tmpH, m_title.c_str());
+        
+        height -= (m_theme->legendPadding + tmpH);
+        width = tmpW;
+        height -= m_theme->legendEntrySpacing;
+
+        fontSize(m_theme->legendEntryFontsize);
+        for (std::size_t i = 0; i < m_data->size(); ++i)
+        {
+            TTF_SizeText(g.font(), m_data->at(i).name.c_str(), &tmpW, &tmpH);
+            height -= (m_theme->legendEntrySpacing);
+
+            color(
+                m_data->at(i).color.r, 
+                m_data->at(i).color.g,
+                m_data->at(i).color.b,
+                m_data->at(i).color.a
+            );
+
+            switch(m_data->at(i).type)
+            {
+            case DrawData::DrawType::POINT:
+                circleFill(
+                    m_position.x + m_theme->legendPadding + m_theme->legendDescSize / 2,
+                    height + tmpH / 2,
+                    tmpH / 3
+                );
+                break;
+            case DrawData::DrawType::LINE:
+                line(
+                    m_position.x + m_theme->legendPadding,
+                    height + tmpH / 2,
+                    m_position.x + m_theme->legendPadding + m_theme->legendDescSize,
+                    height + tmpH / 2
+                );
+                break;
+            default:
+                break;
+            }
+
+            color(
+                m_theme->legendEntryColor.r, 
+                m_theme->legendEntryColor.g, 
+                m_theme->legendEntryColor.b, 
+                m_theme->legendEntryColor.a 
+            );
+            print(
+                m_position.x + m_theme->legendPadding + m_theme->legendDescSize + m_theme->legendDescSpacing, 
+                height, 
+                m_data->at(i).name.c_str()
+            );
+            width = std::max(tmpW, width);
+            height -= tmpH;
+        }
+        height -= m_theme->legendPadding;
+    }
+}
+
+Plot::Plot()
+{
+    m_xaxis = new HorizontalAxis();
+    m_yaxis = new VerticalAxis();
+
+    m_xaxis->setTitle("x");
+    m_yaxis->setTitle("y");
+
+    m_legendLocation = "topright";
+
+    m_legend.setData(&m_drawData);
+    setTheme(Theme::defaultTheme);
+}
+
+void Plot::setTitle(const std::string& title)
+{
+    this->m_title = title;
+    recomputeLayout();
+}
+
+void Plot::setTheme(const Theme& theme)
+{
+    this->m_theme = theme;
+    m_xaxis->setTheme(&m_theme.axisTheme); 
+    m_yaxis->setTheme(&m_theme.axisTheme);
+    m_legend.setTheme(&m_theme.legendTheme);
+    recomputeLayout();
+}
+
+void Plot::setDrawarea(const Rect& drawarea)
+{
+    this->m_drawarea = drawarea;
+}
+
+void Plot::setXaxisType(const std::string& type)
+{
+    Axis* newaxis = nullptr;
+
+    if (type == "log") newaxis = new HorizontalLogAxis();
+    else newaxis = new HorizontalAxis();
+    
+    m_xaxis->copyParams(newaxis);
+    delete m_xaxis;
+    m_xaxis = newaxis;
+    recomputeLayout();
+}
+
+void Plot::setYaxisType(const std::string& type)
+{
+    Axis* newaxis = nullptr;
+    if (type == "log") newaxis = new VerticalLogAxis();
+    else newaxis = new VerticalAxis();
+    
+    m_yaxis->copyParams(newaxis);
+    delete m_yaxis;
+    m_yaxis = newaxis;
+    recomputeLayout();
+}
+
+void Plot::setXaxisTitle(const std::string& title)
+{
+    m_xaxis->setTitle(title);
+    recomputeLayout();
+}
+
+void Plot::setYaxisTitle(const std::string& title)
+{
+    m_yaxis->setTitle(title);
+    recomputeLayout();
+}
+
+void Plot::setXRange(float x, float y)
+{
+    m_xaxis->setBounds(x, y);
+    recomputeLayout();
+}
+
+void Plot::setYRange(float x, float y)
+{
+    m_xaxis->setBounds(x, y);
+    recomputeLayout();
+}
+
+void Plot::setLegendTitle(const std::string& title)
+{
+    m_legend.setTitle(title);
+    recomputeLayout();
+}
+
+void Plot::setCurveName(const std::string& name, int n)
+{
+    createPlot(n);
+    m_drawData[n].name = name;
+    recomputeLayout();
+}
+
+void Plot::setCurveColor(const SDL_Color& color, int n)
+{
+    createPlot(n);
+    m_drawData[n].color = color;
+}
+
+void Plot::setCurveType(const std::string& type, int n)
+{
+    createPlot(n);
+    if (type == "scatter" || type == "point") 
+    {
+        m_drawData[n].type = DrawData::DrawType::POINT;
+    }
+    else if (type == "line" || type == "plot")
+    {
+        m_drawData[n].type = DrawData::DrawType::LINE;
+    }
+}
+
+void Plot::setLegendLocation(const std::string& loc)
+{
+    m_legendLocation = loc;
+}
+
+void Plot::addPlot(float x, float y, int n)
+{
+    auto data = std::make_pair(x, y);
+    bool recompute_x = m_xaxis->updateBounds(x);
+    bool recompute_y = m_yaxis->updateBounds(y);
+    bool recompute = recompute_x || recompute_y;
+
+    if (n >= m_pointsData.size())
+    {
+        createPlot(n);
+    }
+
+    if (m_pointsData[n].size() == 0) 
+    {
+        m_pointsData[n].push_back(move(data));
     }
     else
     {
-        curve.push_back( std::make_pair(x,y) );
-        std::sort(curve.begin(), curve.end(), sort_pred() );
-        curve.erase( curve.begin() );
+        auto insertLoc = std::lower_bound(m_pointsData[n].begin(), m_pointsData[n].end(), data, sort_pred());
+        m_pointsData[n].insert(insertLoc, std::move(data));
+    }
+
+    if (recompute) recomputeLayout();
+}
+
+void Plot::setDrawdata(const DrawData& data, int n)
+{
+    createPlot(n);
+    m_drawData[n] = data;
+}
+
+void Plot::createPlot(int n)
+{
+    if (n >= m_pointsData.size())
+    {
+        m_pointsData.resize(n + 1);
+        m_drawData.resize(n + 1);
+
+        int max_color = m_theme.defaultColorPalette.size();
+        m_drawData[n].type = DrawData::DrawType::LINE;
+        m_drawData[n].color = m_theme.defaultColorPalette.at(n % max_color);
+        m_drawData[n].name = std::to_string(n);
     }
 }
 
-void Plot::minMax(float& fxmin, float& fymin, float& fxmax, float& fymax, int& maxsize) const
+void Plot::clear()
 {
-    int i,j;
-    if (m_dat.size()==0) return;
+    for (auto& ps : m_pointsData)
+    { ps.clear(); }
+}
 
-    fxmin = fxmax = m_dat[0][0].first;
-    fymin = fymax = m_dat[0][0].second;
-    maxsize = m_dat[0].size();
-    for(j=0; j<m_dat.size(); ++j)
+void Plot::recomputeLayout()
+{
+    Grapic& g = Grapic::singleton();
+
+    int tmpX, tmpY;
+    fontSize(m_theme.plotTheme.titleFontSize);
+    TTF_SizeText(g.font(), m_title.c_str(), &tmpX, &tmpY);
+
+    Size m_xaxisSize = m_xaxis->measure();
+    Size m_yaxisSize = m_yaxis->measure();
+
+    Point axisOrigin = Point(
+        this->m_drawarea.pos.x +m_yaxisSize.width,
+        this->m_drawarea.pos.y +m_xaxisSize.height
+    );
+    Size plotSize = Size(
+        this->m_drawarea.size.width  -m_yaxisSize.width  -m_xaxisSize.width,
+        this->m_drawarea.size.height -m_xaxisSize.height -m_yaxisSize.height - tmpY     
+    );
+
+    m_plotarea = Rect(axisOrigin, plotSize);
+    m_xaxis->setPlotarea(m_plotarea);
+    m_yaxis->setPlotarea(m_plotarea);
+
+    Size legendSize = m_legend.measure();
+
+    // default is top left
+    int x = axisOrigin.x;
+    int y = axisOrigin.y + plotSize.height; 
+    
+    if (m_legendLocation.find("bot") != std::string::npos)
     {
-        const Curve& cu = m_dat[j];
-        if (cu.size()>maxsize) maxsize = cu.size();
-        for(i=0; i<cu.size(); ++i)
+        y = axisOrigin.y + legendSize.height;
+    }
+    else if (m_legendLocation.find("center") == 0)
+    {
+        y = axisOrigin.y + plotSize.height / 2 + legendSize.height / 2;
+    }
+
+    if (m_legendLocation.find("right") != std::string::npos)
+    {
+        x = axisOrigin.x + plotSize.width - legendSize.width;
+    }
+    else
+    {
+        std::size_t centerPos = m_legendLocation.find_last_of("center");
+            // 3 = min length {top, bot, center}
+        if (centerPos >= 3 && centerPos != std::string::npos) 
         {
-            if (cu[i].first>fxmax) fxmax = cu[i].first;
-            if (cu[i].first<fxmin) fxmin = cu[i].first;
-            if (cu[i].second>fymax) fymax = cu[i].second;
-            if (cu[i].second<fymin) fymin = cu[i].second;
+            x = axisOrigin.x + plotSize.width / 2 - legendSize.width / 2;
         }
     }
+    
+    
+    m_legend.setPosition(Point(x, y));
 }
 
-void Plot::draw( const Curve& cu, int xmin, int ymin, int xmax, int ymax, float fxmin, float fymin, float fxmax, float fymax) const
+void Plot::drawdata(const Plot::Points& p, const DrawData& d) const
 {
-    int i;
-    float x1, y1, x2, y2;
-    if (cu.size()<2) return;
-    for(i=0; i<cu.size()-1; ++i)
+    color(d.color.r, d.color.g, d.color.b, d.color.a);
+    switch(d.type)
     {
+    case DrawData::DrawType::LINE:
+        if (p.size() > 1)
+        {
+            auto current = p.begin();
 
-        x1 = cu[i].first;
-        y1 = cu[i].second;
-        x2 = cu[i+1].first;
-        y2 = cu[i+1].second;
-
-        x1 = xmin + ((x1-fxmin)/(fxmax-fxmin)) * (xmax-xmin);
-        x2 = xmin + ((x2-fxmin)/(fxmax-fxmin)) * (xmax-xmin);
-        y1 = ymin + ((y1-fymin)/(fymax-fymin)) * (ymax-ymin);
-        y2 = ymin + ((y2-fymin)/(fymax-fymin)) * (ymax-ymin);
-
-        line( x1, y1, x2, y2);
+            for (auto it = ++p.begin(); it != p.end(); ++it)
+            {
+                if (m_xaxis->inBounds(current->first)  && m_xaxis->inBounds(it->first) &&
+                    m_yaxis->inBounds(current->second) && m_yaxis->inBounds(it->second))
+                {
+                    line(
+                        m_xaxis->map(current->first), m_yaxis->map(current->second),
+                        m_xaxis->map(it->first), m_yaxis->map(it->second)
+                    );
+                }
+                current = it;
+            } 
+        }
+        break;
+    case DrawData::DrawType::POINT:
+        for (auto it = p.begin(); it != p.end(); ++it)
+        {
+            if (m_xaxis->inBounds(it->first) && m_yaxis->inBounds(it->second))
+            {
+                circleFill(m_xaxis->map(it->first), m_yaxis->map(it->second), 3);
+            }
+        }
+        break;
+    case DrawData::DrawType::NONE:
+    default:
+        std::cout << "Default" << std::endl;
+        break;
     }
 }
 
-void Plot::draw(int xmin, int ymin, int xmax, int ymax, bool clearOrNot) const
+void Plot::draw()
 {
-    SDL_Color bg = Grapic::singleton().getBackgroundColor();
-    SDL_Color col = Grapic::singleton().getColor();
+    Grapic& g = Grapic::singleton();
+    
+    // Clear area
+    color(
+        m_theme.plotTheme.backgroundColor.r,
+        m_theme.plotTheme.backgroundColor.g,
+        m_theme.plotTheme.backgroundColor.b,
+        m_theme.plotTheme.backgroundColor.a
+    );
+    rectangleFill(
+        m_drawarea.pos.x, 
+        m_drawarea.pos.y, 
+        m_drawarea.pos.x + m_drawarea.size.width, 
+        m_drawarea.pos.y + m_drawarea.size.height
+    );
+    color(
+        m_theme.plotTheme.borderColor.r,
+        m_theme.plotTheme.borderColor.g,
+        m_theme.plotTheme.borderColor.b,
+        m_theme.plotTheme.borderColor.a
+    );
+    rectangle(
+        m_drawarea.pos.x, 
+        m_drawarea.pos.y, 
+        m_drawarea.pos.x + m_drawarea.size.width, 
+        m_drawarea.pos.y + m_drawarea.size.height
+    );
 
-    float fymin;
-    float fymax;
-    float fxmin;
-    float fxmax;
+    // Print title
+    // Centered on drawArea, but it might be better to
+    // center it on plot drawarea
+    int tmpX, tmpY;
+    fontSize(m_theme.plotTheme.titleFontSize);
+    color(
+        m_theme.plotTheme.titleColor.r, 
+        m_theme.plotTheme.titleColor.g, 
+        m_theme.plotTheme.titleColor.b, 
+        m_theme.plotTheme.titleColor.a
+    );
+    TTF_SizeText(g.font(), m_title.c_str(), &tmpX, &tmpY);
+    print(
+        m_plotarea.pos.x + m_plotarea.size.width / 2 - tmpX / 2, 
+        m_drawarea.pos.y + m_drawarea.size.height - tmpY, 
+        m_title.c_str()
+    );
 
-    if (clearOrNot)
+    m_xaxis->draw();
+    m_yaxis->draw();
+
+    for (std::size_t i = 0; i < m_pointsData.size(); ++i)
     {
-        color( bg.r, bg.g, bg.b);
-        rectangleFill( xmin, ymin, xmax, ymax);
-
-        backgroundColor( bg.r, bg.g, bg.b);
-        color(col.r, col.g, col.b);
+        drawdata(m_pointsData.at(i), m_drawData.at(i));
     }
 
-    // Draw axis
-    xmin+=25;
-    ymin+=20;
-    rectangle(xmin,ymin,xmax,ymax);
-
-    //fxmin = cu[0].first;
-    //fxmax = cu[ cu.size()-1 ].first;
-    int maxsize;
-    minMax( fxmin, fymin, fxmax, fymax, maxsize);
-    if (m_nb_plot_max>0)
-        fxmax = fxmin + ((fxmax-fxmin) * ((float)(m_nb_plot_max))) / maxsize;
-
-    fontSize(11);
-    print( xmin-25, ymin-5, fymin);
-    print( xmin-25, ymax-15, fymax);
-
-    print( xmin-5, ymin-20, fxmin);
-    print( xmax-30, ymin-20, fxmax);
-
-    Grapic& gr = Grapic::singleton();
-    SDL_Color save = gr.getColor();
-    const int N = 5;
-    static const SDL_Color colcu[] = { {0,255,255, 255}, {0,255,0, 255}, {0,0,255, 255}, {255,255,0, 255}, {255,0,255, 255} };
-    int i;
-    for(i=0; i<m_dat.size(); ++i)
-    {
-        color( colcu[i%N].r, colcu[i%N].g, colcu[i%N].b, colcu[i%N].a );
-        draw( m_dat[i], xmin, ymin, xmax, ymax, fxmin, fymin, fxmax, fymax);
-    }
-    color(save.r,save.g,save.b,save.a);
+    m_legend.draw();
 }
 
-
-
-
+Plot::~Plot()
+{
+    delete m_xaxis;
+    delete m_yaxis;
+}
 
 //=========================================================================================================================
 //=========================================================================================================================
@@ -1927,25 +2746,5 @@ void polygon(int p[][2], unsigned int number)
         grapic::line(p[i % number][0], p[i % number][1], p[(i + 1) % number][0], p[(i + 1)% number][1]);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 } // namespace

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -1659,6 +1659,15 @@ void Axis::setTicks(const std::vector<float>& ticks)
     this->m_ticksSet = true;
 }
 
+void Axis::resetBounds()
+{
+    if (!m_boundsSet)
+    {
+        m_max = -std::numeric_limits<float>::infinity();
+        m_min =  std::numeric_limits<float>::infinity();
+    }
+}
+
 void Axis::updateTicks(std::size_t tickCount)
 {
     if (!m_ticksSet)
@@ -2253,6 +2262,11 @@ void Plot::clear()
 {
     for (auto& ps : m_pointsData)
     { ps.clear(); }
+
+    xaxis->resetBounds();
+    yaxis->resetBounds();
+
+    recomputeLayout();
 }
 
 void Plot::recomputeLayout()

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -2263,8 +2263,8 @@ void Plot::clear()
     for (auto& ps : m_pointsData)
     { ps.clear(); }
 
-    xaxis->resetBounds();
-    yaxis->resetBounds();
+    m_xaxis->resetBounds();
+    m_yaxis->resetBounds();
 
     recomputeLayout();
 }

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -326,6 +326,8 @@ public:
 
     void setTicks();
 
+    void resetBounds();
+
     virtual void draw() const = 0;
 
     virtual ~Axis();

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -36,6 +36,11 @@ along with Grapic.  If not, see <http://www.gnu.org/licenses/>.
 #include <chrono>
 #include <vector>
 #include <algorithm>
+#include <limits>
+#include <sstream>
+#include <list>
+#include <array>
+#include <memory>
 
 #include <SDL.h>
 #include <SDL_ttf.h>
@@ -183,32 +188,280 @@ protected:
     bool m_visible;
 };
 
+struct NumberFormatter
+{
+public:
+    virtual std::string format(float number) const = 0;
+    
+    virtual ~NumberFormatter();
+};
 
+struct FixedPrecisionFormatter : public NumberFormatter
+{
+public:
+    FixedPrecisionFormatter(unsigned int precision = 2);
 
-typedef std::vector< std::pair<float,float> > Curve;
+    std::string format(float number) const override;
+private:
+    unsigned int precision;
+};
+
+struct ScientificFormatter : public NumberFormatter
+{
+public:
+    ScientificFormatter(unsigned int precision = 2);
+
+    std::string format(float number) const override;
+private:
+    unsigned int precision;
+};
+
+struct AxisTheme
+{
+    // Ownership would be unclear with raw pointer...
+    // To keep member public (which should by design), 
+    // std::shared_ptr will enforce proper deletion
+    // while keeping copy constructor active
+    std::shared_ptr<NumberFormatter> formatter;
+
+    SDL_Color axisColor;
+    SDL_Color gridColor;
+
+    bool showGrid;
+    bool showTicks;
+    bool showTitle;
+    int defaultTicksCount;
+
+    int ticksSize;
+    int ticksSpacing;
+    int titleFontSize;
+    int ticksFontSize;
+};
+
+struct PlotTheme
+{
+    SDL_Color titleColor;
+    SDL_Color backgroundColor;
+    SDL_Color borderColor;
+    
+    int titleFontSize;
+};
+
+struct LegendTheme
+{
+    int legendEntrySpacing;
+    int legendPadding;
+    int legendDescSize;
+    int legendDescSpacing;
+
+    int legendTitleFontsize;
+    int legendEntryFontsize;
+
+    SDL_Color legendEntryColor;
+    SDL_Color legendTitleColor;
+    SDL_Color backgroundColor;
+};
+
+struct Theme
+{
+    Theme();
+
+    AxisTheme axisTheme;
+    PlotTheme plotTheme;
+    LegendTheme legendTheme;
+
+    std::array<SDL_Color, 10> defaultColorPalette;
+
+    static Theme defaultTheme;
+};
+
+struct Point
+{
+    Point();
+    Point(int x, int y);
+
+    int x, y;  
+};
+
+struct Size
+{
+    Size();
+    Size(int w, int h);
+
+    int width;
+    int height;
+};
+
+struct Rect
+{
+    Rect();
+    Rect(const Point& p, const Size& s);
+    Rect(int x, int y, int w, int h);
+
+    Point pos;
+    Size size;
+};
+
+class Axis
+{
+public:
+    Axis();
+
+    virtual Size measure() const = 0;
+    virtual float map(float value) const = 0;
+
+    // Design choice : operator= and abstract classes...
+    virtual void copyParams(Axis* to) const;
+
+    void setTheme(AxisTheme* theme);
+    void setTitle(const std::string& title);
+    void setPlotarea(const Rect& area);
+    
+    bool inBounds(float value) const;
+    void setBounds(float min, float max);
+    bool updateBounds(float value);
+
+    void setTicks(const std::vector<float>& ticks);
+    void updateTicks(std::size_t tick_count);
+
+    void setTicks();
+
+    virtual void draw() const = 0;
+
+    virtual ~Axis();
+public:
+    AxisTheme* m_theme;
+    std::string m_title;
+    
+    float m_max;
+    float m_min;
+    std::vector<float> m_ticks;
+
+    bool m_boundsSet;
+    bool m_ticksSet;
+
+    Rect m_plotarea;
+};
+
+class VerticalAxis : public Axis
+{
+public:
+    Size measure() const override;
+    virtual float map(float value) const override;
+    void draw() const override;
+private:
+};
+
+class HorizontalAxis : public Axis
+{
+public:
+    Size measure() const override;
+    virtual float map(float value) const override;
+    void draw() const override;
+};
+
+class VerticalLogAxis : public VerticalAxis
+{
+public:
+    virtual float map(float value) const override;
+};
+
+class HorizontalLogAxis : public HorizontalAxis
+{
+public:
+    virtual float map(float value) const override;
+};
+
+struct DrawData
+{
+    enum class DrawType
+    {
+        NONE, 
+        POINT, 
+        LINE
+    } type;
+    SDL_Color color;  
+    std::string name;
+
+    DrawData();
+};
+
+class Legend
+{
+public:
+    Legend();
+
+    void setTitle(const std::string& title);
+    void setTheme(LegendTheme* theme);
+    void setData(std::vector<DrawData>* data);
+    void setPosition(const Point& p);
+    void clear();
+
+    Size measure() const;
+    void draw  () const;
+private:
+    LegendTheme* m_theme;
+
+    Point m_position;
+    std::string m_title;
+    std::vector<DrawData>* m_data;
+};
+
 class Plot
 {
 public:
+    using Points = std::list<std::pair<float, float>>;
+
     Plot();
+
+    void setTitle(const std::string& title);
+    void setTheme(const Theme& theme);
+    void setDrawarea(const Rect& drawarea); 
+    
+    void setXaxisType(const std::string& type);
+    void setYaxisType(const std::string& type);
+    void setXaxisTitle(const std::string& title);
+    void setYaxisTitle(const std::string& title);
+    void setXRange(float x, float y);
+    void setYRange(float x, float y);
+
+    void setCurveName(const std::string& name, int n);
+    void setCurveColor(const SDL_Color& color, int n);
+    void setCurveType(const std::string& type, int n);
+
+    void setLegendTitle(const std::string& title);
+    void setLegendLocation(const std::string& loc);
+
+
+    void addPlot(float x, float y, int n);
+    void setDrawdata(const DrawData& data, int n);
+    
+
     void clear();
-    void setSize(const int n);
-    void add(float x, float y, int curve_n);
-    void draw(int xmin, int ymin, int xmax, int ymax, bool clearOrNot) const;
-    void draw( const Curve& cu, int xmin, int ymin, int xmax, int ymax, float fxmin, float fymin, float fxmax, float fymax) const;
-    void minMax(float& fxmin, float& fymin, float& fxmax, float& fymax, int& maxsize) const;
+    void draw();
 
-protected:
-    std::vector< Curve  > m_dat;
-    int m_nb_plot_max;
+    ~Plot();
+private:
+    void createPlot(int n);
+    void recomputeLayout();
+    void drawdata(const Plot::Points& p, const DrawData& d) const;
+    
+private:
+    std::vector<Points> m_pointsData;
+    std::vector<DrawData> m_drawData;
+
+    Rect m_drawarea;
+    Rect m_plotarea;
+
+    std::string m_title;
+    std::string m_legendLocation;
+
+    Theme m_theme;
+
+    Legend m_legend;
+    Axis* m_xaxis;
+    Axis* m_yaxis;
 };
-
-
-
-/// \endcond
-
-
-
-
 
 
 //==================================================================================================
@@ -672,35 +925,93 @@ inline int caseToPixel(const Menu& m, int c, int ymin, int ymax)
     return m.caseToPixel(c,ymin,ymax);
 }
 
+
 //! @todo: plot: setColor for each curves
 //! @todo: setRangeXMinMax for each curves
+
+//! \brief Set plot title 
+inline void plot_title(Plot& p, const char* title)
+{
+    p.setTitle(title);
+}
+
+//! \brief Set x axis title
+inline void plot_xaxisTitle(Plot& p, const char* title)
+{
+    p.setXaxisTitle(title);
+}
+
+//! \brief Set x axis type. Types are "lin" for linear or "log" for log-scaled axis.
+inline void plot_xaxisType(Plot& p, const char* type)
+{
+    p.setXaxisType(type);
+}
+
+//! \brief Set y axis title.
+inline void plot_yaxisTitle(Plot& p, const char* title)
+{
+    p.setYaxisTitle(title);
+}
+
+//! \brief Set y axis type. Types are "lin" for linear or "log" for log-scaled axis.
+inline void plot_yaxisType(Plot& p, const char* type)
+{
+    p.setYaxisType(type);
+}
+
+//! \brief Add a point (x,y=f(x)) to the curve number curve_n. 
+inline void plot_add(Plot& p, float x, float y, int n)
+{
+    p.addPlot(x, y, n);
+}
+
+//! \brief Set name of the curve number n.
+inline void plot_curveName(Plot& p, int n, const char* name)
+{
+    p.setCurveName(name, n);
+}
+
+//! \brief Set color of the curve number n.
+inline void plot_curveColor(Plot& p, int n, unsigned char r, unsigned char g, unsigned char b, unsigned char a = 255)
+{
+    p.setCurveColor({r, g, b, a}, n);
+}
+
+//! \brief Set type of the curve number n. Types are "scatter" for points or "line" for line plot.
+inline void plot_curveType(Plot& p, int n, const char* type)
+{
+    p.setCurveType(type, n);
+}
+
+//! \brief Set the area where the plot is drawn. 
+inline void plot_area(Plot& p, int xmin, int ymin, int xmax, int ymax)
+{
+    p.setDrawarea(Rect(xmin, ymin, xmax - xmin, ymax - ymin));
+}
+
+//! \brief Set the location of the legend. Location are "[top|bot|center]|[left|right|center]"
+inline void plot_legendLocation(Plot& p, const char* location)
+{
+    p.setLegendLocation(location);
+}
+
+//! \brief Set legend title
+inline void plot_legendTitle(Plot& p, const char* title)
+{
+    p.setLegendTitle(title);
+}
+
+//! \brief Draw the plot
+inline void plot_draw(Plot& p)
+{
+    p.draw();
+}
 
 //! \brief Clear the data stored
 inline void plot_clear(Plot& p )
 {
     p.clear();
 }
-
-//! \brief Define the size of the stored value of the funtion (<0 means infinity)
-inline void plot_setSize(Plot& p, const int n)
-{
-    p.setSize(n);
-}
-
-//! \brief Add a point (x,y=f(x)) to the curve number curve_n
-inline void plot_add(Plot& p, float x, float y, int curve_n=0)
-{
-    p.add(x,y,curve_n);
-}
-
-//! \brief Draw the curve in the rectangle (xmin,ymin,xmax,ymax); clear the rectangle if clearOrNot is true
-inline void plot_draw( const Plot& p, int xmin, int ymin, int xmax, int ymax, bool clearOrNot=true)
-{
-    p.draw(xmin,ymin,xmax,ymax,clearOrNot);
-}
-
-
-
 
 /**
     \brief Draw a triangle from the vertices (x1, y1), (x2, y2) and (x3, y3). (Code provided by Bastien DOIGNIES, many thanks)

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -331,7 +331,7 @@ public:
     virtual void draw() const = 0;
 
     virtual ~Axis();
-public:
+private:
     AxisTheme* m_theme;
     std::string m_title;
     

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -331,7 +331,7 @@ public:
     virtual void draw() const = 0;
 
     virtual ~Axis();
-private:
+protected:
     AxisTheme* m_theme;
     std::string m_title;
     


### PR DESCRIPTION
Big update on plot system for Grapic library. The update brings a full support for axes (linear, log-scaled), legends and plots (scatter, line). Most of the design can be customized (~25 parameters to controll the overall look).  

Notes: 
- Performance can be low when the values changes by magnitudes and the plot needs to recompute it's entire layout every frame. 
- Proper ticks system should also be developped. Right now it is very simple and can be ugly when using high ranges and log scale (ticks text will overlapp).
- Most of the PR is addition to the library. The old plot system was deleted however. Only a slight modification of Grapic was necessary : blend mode is not resetted anymore when drawing circles or ellipses (see line 776 of Grapic.cpp for example). I couldn't detect any difference in the drawing of such objects.   

Here is a screenshot of the modernized "tuto8_Plot" : 
![image](https://user-images.githubusercontent.com/92028614/156893853-6e51af04-685d-4316-a56f-dc29dd2ee518.png)
