### PR TITLE
Menu changes feedback

### DIFF
--- a/apps/tutorials/tuto6_Menu.cpp
+++ b/apps/tutorials/tuto6_Menu.cpp
@@ -42,6 +42,24 @@ int main(int , char** )
     {
         winClear();
         menu_draw(m, 5,5, 100, 102);
+        switch(menu_has_changed(m))
+        {
+            case 0:
+                std::cout << "Selecting 0-th item" << std::endl;
+                break;
+            case 1:
+                std::cout << "Selecting 1-th item" << std::endl;
+                break;
+            case 2:
+                std::cout << "Selecting 2-th item" << std::endl;
+                break;
+            case 3:
+                std::cout << "Selecting 3-th item" << std::endl;
+                break;
+            default:
+                break;
+        }
+
         switch(menu_select(m))
         {
             case 0 : dat.n = 5; draw(dat); break;

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -163,7 +163,7 @@ const SDL_Surface* Image::surface() const
     bool Image::isInit() const { return m_surface && m_texture; }
 
 
-Menu::Menu() : m_select(0), m_visible(true) {}
+Menu::Menu() : m_select(0), m_has_changed(false), m_visible(true) {}
 
 void Menu::change(int i, const std::string& str)
 {

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -173,6 +173,16 @@ void Menu::change(int i, const std::string& str)
         std::cerr<<"menu_change(...): i is not in the range of the menu"<<std::endl;
 }
 
+bool Menu::has_changed()
+{
+    if (m_has_changed)
+    {
+        m_has_changed = false;
+        return true;
+    }
+    return false;
+}
+
     Plot::Plot() : m_nb_plot_max(-1) {}
 
     void Plot::clear()
@@ -197,7 +207,11 @@ void Menu::setSelect(int s)
 {
     assert(s>=0);
     assert(s<m_txt.size());
-    m_select=s;
+    if (s != m_select)
+    {
+        m_has_changed = true;
+        m_select = s;
+    }
 }
 int Menu::caseToPixel(int c, int ymin, int ymax) const
 {
@@ -1443,7 +1457,12 @@ void Menu::draw(int xmin, int ymin, int xmax, int ymax)
         mousePos(x, y);
         if ((x>xmin) && (x<xmax) && (y>ymin) && (y<ymax))
         {
-            m_select = m_txt.size()-1 - (y-ymin) / ((ymax-ymin)/m_txt.size());
+            int new_select = m_txt.size()-1 - (y-ymin) / ((ymax-ymin)/m_txt.size()); 
+            if (new_select != m_select)
+            {
+                m_has_changed = true;
+                m_select = new_select;
+            } 
         }
     }
 

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -176,10 +176,12 @@ public:
     int caseToPixel(int c, int ymin, int ymax) const;
     void draw(int xmin, int ymin, int xmax, int ymax);
     void add(const std::string& str);
+    bool has_changed();
 
 protected:
     std::vector<std::string> m_txt;
     int m_select;
+    bool m_has_changed;
     bool m_visible;
 };
 
@@ -646,6 +648,20 @@ inline void menu_add(Menu& m, const std::string& str)
 inline void menu_change(Menu& m, int i, const std::string& str)
 {
     m.change(i,str);
+}
+
+//! \brief Check if the menu item was changed.
+//
+// This functions returns the newly selected item only once per change. 
+// Therefore, it can be used to perform 'in-loop' initialization. 
+inline int menu_has_changed(Menu& m)
+{
+    if (m.has_changed())
+    {
+        return m.select();
+    }
+    // Invalid item
+    return -1;
 }
 
 //! \brief Draw the menu on the screen. See menu_add for an example of usage.


### PR DESCRIPTION
While teaching LIFAMI class, multiple students had trouble to perform initialization of their classes with menu in the event loop. The situation arise when students wants to be able to restart their examples without quitting the program. 
- The solution most of them found is to create special menu items that perform initialization and then switch to others when it is done. This solution indeed works but I find it very hacky and not of good practice. 

This small update allow to check for changes on the menu item and pe rform one time initialization as std::cout shows in the tuto6_Menu tutorial.  