### PR TITLE
Add fps limit

### DIFF
--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -297,6 +297,13 @@ inline void winQuit()
     }
 }
 
+/** \brief If set to true, limit the framerate (to monitor framerate) to save ressources on low end pcs
+*/
+inline void savePerformanceMode(bool reduceFPS)
+{
+    SDL_GL_SetSwapInterval(reduceFPS);
+}
+
 /** \brief Change the default color (unsigned char values between 0 and 255)
 */
 inline void color(unsigned char _r = 255, unsigned char _g = 255, unsigned char _b = 255, unsigned char _a = 255)


### PR DESCRIPTION
By default in grapic, the rendering is done more often than the actual frame rate of the monitor. This means that a lot of unnecessary computation is done.
By limiting the frame rate to match the monitor frame rate, less computation is done, saving battery on laptops.  