### PR TITLE
Added qToQuit function

### DIFF
--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -147,6 +147,7 @@ void Grapic::init(const char* name, int w, int h, int posx, int posy, SDL_Window
     m_height = h;
     m_quit = false;
     m_anim = false;
+    press_q_quit = true;
 
     SDL_SetRenderDrawBlendMode( m_renderer, SDL_BLENDMODE_BLEND);
 
@@ -282,7 +283,7 @@ bool Grapic::manageOneEvent(SDL_Event event)
             //last_key= event.key;    // conserver le dernier evenement
         }
 
-        if ((event.key.keysym.sym == SDLK_ESCAPE) || (event.key.keysym.sym == SDLK_q))
+        if ((event.key.keysym.sym == SDLK_ESCAPE) || (event.key.keysym.sym == SDLK_q && press_q_quit))
             m_quit = true;
         else if (event.key.keysym.sym == SDLK_F12)
         {
@@ -472,6 +473,10 @@ void Grapic::setFont(int s, const char* ttf)
         assert(0);
         exit(1);
     }
+}
+
+void Grapic::qToQuit(bool enable) {
+	press_q_quit = enable;
 }
 
 
@@ -1019,6 +1024,10 @@ Uint32 image_get(SDL_Surface *surface, int x, int y)
     default:
         return 0;
     }
+}
+
+void qToQuit(bool enable) {
+	Grapic::singleton().qToQuit(enable);
 }
 
 

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -477,6 +477,12 @@ void Grapic::setFont(int s, const char* ttf)
 
 void Grapic::qToQuit(bool enable) {
 	press_q_quit = enable;
+	// Affiche si l'utilisateur peut ou non utiliser 'q' pour quitter
+	if (press_q_quit) {
+		std::cout << "L'utilisateur peut utiliser 'q' pour quitter la fenetre Grapic" << std::endl;
+	} else {
+		std::cout << "Utilisation de la touche 'q' pour quitter la fenetre Grapic desactivee" << std::endl;
+	}
 }
 
 

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -299,6 +299,13 @@ inline void winQuit()
     }
 }
 
+/** \brief If set to true, limit the framerate (to monitor framerate) to save ressources on low end pcs
+*/
+inline void savePerformanceMode(bool reduceFPS)
+{
+    SDL_GL_SetSwapInterval(reduceFPS);
+}
+
 /** \brief Change the default color (unsigned char values between 0 and 255)
 */
 inline void color(unsigned char _r = 255, unsigned char _g = 255, unsigned char _b = 255, unsigned char _a = 255)

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -789,7 +789,7 @@ void polygon(int p[][2], unsigned int number);
     qToQuit(true); // Taper la touche 'q' fermera la fenêtre
     ~~~~~~~~~~~~~~~
  */
-void qToQuit(bool enable = true);
+void qToQuit(bool enable);
 
 
 

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -84,6 +84,7 @@ public:
     void setFont(int s, const char* ttf=NULL);
     int keyHasBeenPressed(unsigned int sc);
     void setKeyRepeatMode(bool kr);
+	void qToQuit(bool enable);
 
     const SDL_Window* window() const { return m_window; }
     SDL_Window* window() { return m_window; }
@@ -111,6 +112,7 @@ protected:
     int m_fontSize;
     bool m_quit;
     bool m_anim;
+	bool press_q_quit;
     SDL_Color m_currentColor;
     SDL_Color m_backgroundColor;
     std::vector<int> m_keyStates;
@@ -295,13 +297,6 @@ inline void winQuit()
         delete Grapic::currentGrapic;
         Grapic::currentGrapic = nullptr;
     }
-}
-
-/** \brief If set to true, limit the framerate (to monitor framerate) to save ressources on low end pcs
-*/
-inline void savePerformanceMode(bool reduceFPS)
-{
-    SDL_GL_SetSwapInterval(reduceFPS);
 }
 
 /** \brief Change the default color (unsigned char values between 0 and 255)
@@ -779,6 +774,15 @@ void polygonFill(int p[][2], unsigned int number);
     ~~~~~~~~~~~~~~~
  */
 void polygon(int p[][2], unsigned int number);
+
+
+/** \brief Permet à l'utilisateur d'activer/désactiver la fermeture de la fenêtre sur l'appui de la touche 'q'
+    ~~~~~~~~~~~~~~~{.c}
+    qToQuit(false); // Taper la touche 'q' ne fermera pas la fenêtre
+    qToQuit(true); // Taper la touche 'q' fermera la fenêtre
+    ~~~~~~~~~~~~~~~
+ */
+void qToQuit(bool enable = true);
 
 
 


### PR DESCRIPTION
While using Grapic, especially when making applications that requires keyboard input from the user, e.g. games, a popular control scheme among French users is using the ZQSD keys (forward, left, backward, right).
However, Grapic automatically closes the window if the 'q' key is pressed. But as I previously mentioned, the "Q" key is already being used as the left movement key in most games.
This makes creating an intuitive control scheme with Grapic difficult.

The solution I propose is adding a function that will toggle this behaviour based upon the user's choice.
The code I provided in this pull request adds the `qToQuit(bool enable)` function, which, given a boolean, will result in this behaviour being turned on or off.

The code was successfully tested, and is entirely documented as is every other Grapic function, and should thus be seamlessly integrated in the website documentation without any manual intervention.

This is a very minor change, but I think it would be a welcomed addition into the Grapic library.

Thank you for your time.
Best regards !