### PR TITLE
Added selectFont function for Grapic.

### DIFF
--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -522,6 +522,10 @@ void Grapic::setFont(int s, const char* ttf)
     }
 }
 
+int Grapic::getFontSize() {
+	return m_fontSize;
+}
+
 void Grapic::qToQuit(bool enable) {
 	press_q_quit = enable;
 	// Affiche si l'utilisateur peut ou non utiliser 'q' pour quitter

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -84,7 +84,8 @@ public:
     void setFont(int s, const char* ttf=NULL);
     int keyHasBeenPressed(unsigned int sc);
     void setKeyRepeatMode(bool kr);
-  	void qToQuit(bool enable);
+    int getFontSize();
+    void qToQuit(bool enable);
     float framesPerSecond();
     unsigned int lastFrameTime();
 
@@ -518,6 +519,12 @@ inline void fontSize(int s)
     Grapic::singleton().setFont(s);
 }
 
+/** \brief Changes the default font to the a the given path (must be a .ttf file)
+*/
+inline void selectFont(const char* path)
+{
+    Grapic::singleton().setFont(Grapic::singleton().getFontSize(), path);
+}
 
 /** \brief Print the text txt , up left corner is (x,y)
     ~~~~~~~~~~~~~~~{.c}


### PR DESCRIPTION
This function allows the end user to select a new font to be used in Grapic's `print` method or `Menu` class.

The changes are fairly small (~15 lines) and include a documentation.