### PR TITLE
Screen size without using SDL functions and fullscreen on launch + scripts

### DIFF
--- a/run-lifami-cb20-linux.sh
+++ b/run-lifami-cb20-linux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if command -v premake5 > /dev/null 2>&1; then
+    premake5
+else
+    if [ -x ./script/premake5.linux ]; then
+        ./script/premake5.linux --os=linux --file=premake5.lua --lifami codeblocks 
+        ./script/premake5.linux --os=linux --file=premake5.lua --lifami gmake
+    else
+        echo "Installer premake5 svp"
+    fi
+fi

--- a/script/premake5.linux.sh
+++ b/script/premake5.linux.sh
@@ -2,8 +2,8 @@
 if command -v premake5 > /dev/null 2>&1; then
     premake5 $*
 else
-    if [ -x script/premake5.exe.linux ]; then
-        script/premake5.exe.linux $*
+    if [ -x premake5.linux ]; then
+        premake5.linux $*
     else
         echo "Installer premake5 svp"
     fi

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -1034,28 +1034,28 @@ void circleFill(int xc, int yc, int circleR)
 
 void drawArrow(int xa, int ya, int xb, int yb)
 {
-    // Dessiner la tige de la fl�che
+    // Dessiner la tige de la flèche
     line(xa, ya, xb, yb);
 
-    // Calculer les coordonn�es pour la pointe de la fl�che
+    // Calculer les coordonnées pour la pointe de la flèche
     int dx = xb - xa;
     int dy = yb - ya;
     int length = sqrt(dx*dx + dy*dy);
-    int arrowSize = 10; // Taille de la pointe de la fl�che
+    int arrowSize = 10; // Taille de la pointe de la flèche
 
     int x1 = xb - (arrowSize * dx) / length;
     int y1 = yb - (arrowSize * dy) / length;
 
-    // Dessiner la pointe de la fl�che
+    // Dessiner la pointe de la flèche
     line(xb, yb, x1, y1);
 
-    // Calculer les coordonn�es pour les "ailes" de la fl�che
+    // Calculer les coordonnées pour les "ailes" de la flèche
     int x2 = x1 + (arrowSize * dy) / length;
     int y2 = y1 - (arrowSize * dx) / length;
     int x3 = x1 - (arrowSize * dy) / length;
     int y3 = y1 + (arrowSize * dx) / length;
 
-    // Dessiner les "ailes" de la fl�che
+    // Dessiner les "ailes" de la flèche
     line(xb, yb, x2, y2);
     line(xb, yb, x3, y3);
 }

--- a/src/Grapic.cpp
+++ b/src/Grapic.cpp
@@ -566,6 +566,18 @@ inline SDL_Renderer* renderer()
     return Grapic::singleton().renderer();
 }
 
+void getScreenSize(int &w, int &h) {
+    SDL_DisplayMode DM;
+    if (SDL_GetCurrentDisplayMode(0, &DM) != 0) {
+        w = -1;
+        h = -1;
+        std::cout << "Erreur lors de l'obtention de la dÃ©finition de l'Ã©cran.";
+        return;
+    }
+    w = DM.w;
+    h = DM.h;
+}
+
 void winSetPosition(int w, int h, int px, int py, bool fullscreen)
 {
     if (fullscreen) SDL_SetWindowFullscreen( Grapic::singleton().window(), SDL_WINDOW_FULLSCREEN );
@@ -1022,28 +1034,28 @@ void circleFill(int xc, int yc, int circleR)
 
 void drawArrow(int xa, int ya, int xb, int yb)
 {
-    // Dessiner la tige de la flèche
+    // Dessiner la tige de la flï¿½che
     line(xa, ya, xb, yb);
 
-    // Calculer les coordonnées pour la pointe de la flèche
+    // Calculer les coordonnï¿½es pour la pointe de la flï¿½che
     int dx = xb - xa;
     int dy = yb - ya;
     int length = sqrt(dx*dx + dy*dy);
-    int arrowSize = 10; // Taille de la pointe de la flèche
+    int arrowSize = 10; // Taille de la pointe de la flï¿½che
 
     int x1 = xb - (arrowSize * dx) / length;
     int y1 = yb - (arrowSize * dy) / length;
 
-    // Dessiner la pointe de la flèche
+    // Dessiner la pointe de la flï¿½che
     line(xb, yb, x1, y1);
 
-    // Calculer les coordonnées pour les "ailes" de la flèche
+    // Calculer les coordonnï¿½es pour les "ailes" de la flï¿½che
     int x2 = x1 + (arrowSize * dy) / length;
     int y2 = y1 - (arrowSize * dx) / length;
     int x3 = x1 - (arrowSize * dy) / length;
     int y3 = y1 + (arrowSize * dx) / length;
 
-    // Dessiner les "ailes" de la flèche
+    // Dessiner les "ailes" de la flï¿½che
     line(xb, yb, x2, y2);
     line(xb, yb, x3, y3);
 }

--- a/src/Grapic.h
+++ b/src/Grapic.h
@@ -137,7 +137,7 @@ protected:
     void updateFrameCounter();
 
     static Grapic* currentGrapic;
-    friend void winInit(const char* name, int w, int h, int posx, int posy);
+    friend void winInit(const char* name, int w, int h, int posx, int posy, bool fullscreen);
     friend void winQuit();
 };
 
@@ -242,10 +242,12 @@ protected:
 /** \brief Initialize the window with a size w,h and a position (posx,posy).
     If posx<0 or posy<0, the position is centered.
 */
-inline void winInit(const char* name, int w, int h, int posx=-1, int posy=-1)
+inline void winInit(const char* name, int w, int h, int posx=-1, int posy=-1, bool fullscreen=false)
 {
     Grapic::currentGrapic = new Grapic();
-    Grapic::singleton(false).init(name,w,h,posx,posy);
+    SDL_WindowFlags flag;
+    if (fullscreen) flag = SDL_WINDOW_FULLSCREEN;
+    Grapic::singleton(false).init(name,w,h,posx,posy,flag);
 }
 
 /** \brief Clear the window with the default background color
@@ -277,6 +279,10 @@ inline void winClearEvent()
 {
     grapic::Grapic::singleton().clearEvent();
 }
+
+/** \brief Sets the reference-passed variables to the dimension of the screen (in pixels) or -1 if an error occured.
+*/
+void getScreenSize(int &w, int &h);
 
 /** \brief Change the size (w,h), the position(ps,py) or the fullscreen on/off
      Set a negative parameter to let him as it is.


### PR DESCRIPTION
I added a function to allow users to get the screen size without resorting to using the bare SDL2 lib
```c++
void getScreenSize(int &w, int &h);
```
(ex:it can be used to determine a machine-specific window size instead of a constant one) and added a fullscreen option in `winInit()`. Its header now looks like this:
```c++
void winInit(const char* name, int w, int h, int posx, int posy, bool fullscreen);
```
(by default the fullscreen option is set to false and is optional, backwards-compatibility is preserved)
I also added a script to generate LIFAMI code-blocks projects for linux more easily.